### PR TITLE
made map fullscreen and changed route view so it stays within the v…

### DIFF
--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -3,7 +3,8 @@
   z-index: 0;
   top: 0;
   width: 100%;
-  height: calc(100vh - 8vh - 144px - 6px)
+  height: 92vh;
+  // height: calc(100vh - 8vh - 144px - 6px)
   // viewport - navbar - carousel - space above navbar
 }
 
@@ -28,4 +29,8 @@
 
 .mapboxgl-canvas {
   z-index: -2;
+}
+
+.mapboxgl-ctrl-bottom-left, .mapboxgl-ctrl-bottom-right {
+  bottom : 140px !important;
 }

--- a/app/javascript/plugins/init_mapbox.js
+++ b/app/javascript/plugins/init_mapbox.js
@@ -21,7 +21,7 @@ const initMapbox = () => {
     });
 
     // This makes the route stay withing the viewport
-    map.setPadding({top: 50, bottom: 150}); 
+    map.setPadding({top: 40, bottom: 150}); 
 
     const markers = JSON.parse(mapElement.dataset.markers);
     markers.forEach((marker) => {

--- a/app/javascript/plugins/init_mapbox.js
+++ b/app/javascript/plugins/init_mapbox.js
@@ -20,6 +20,9 @@ const initMapbox = () => {
       zoom: 13
     });
 
+    // This makes the route stay withing the viewport
+    map.setPadding({top: 50, bottom: 150}); 
+
     const markers = JSON.parse(mapElement.dataset.markers);
     markers.forEach((marker) => {
       const markerHtml = document.createElement('div')


### PR DESCRIPTION
- Made map fullscreen to get rid of ugly white background
- Changed route view so it stays within the viewport and not behind the cards
- Moved mapbox logo and geolocation buttons so they're above the cards

![image](https://user-images.githubusercontent.com/80769492/133223986-c9dd7893-e1d2-4c90-8a9f-dfa07a1cc4a0.png)
